### PR TITLE
Mention responsible/co-ordinated disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A note on politics: Political discussions are not banned, but we don't tolerate 
   * We respect people’s boundaries and identities.
   * We refrain from using language that can be considered oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
   * We avoid using offensive topics as a form of humor.
-  * We do not suggest or speculate on ways of breaking the law, or the security measures of Monzo and other banks.
+  * We do not suggest or speculate on ways of breaking the law. We encourage the practice of [responsibly disclosing](https://www.bugcrowd.com/resource/what-is-responsible-disclosure/) security vulnerabilities.
 
 #### We actively work towards:
 


### PR DESCRIPTION
I don't see that having a blanket ban on vulnerability discussion is particularly useful or beneficial, instead we should encourage responsible disclosure.

Also "breaking security measures" is super vague. Is re-signing an APK so you can disable cert pinning and take a look at how the app works breaking a security measure? What about decompiling/disassembling it in the first place? Is discussing Magisk problematic, since it enables you to bypass root detection in some banking apps? What about fixed vulnerabilities?